### PR TITLE
fix(publish): pin `yarn publish` to registry.npmjs.org

### DIFF
--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -58,4 +58,10 @@ else
 fi
 
 # Publish with the appropriate tag
-yarn publish --tag "$TAG"
+#
+# Explicit --registry is required because yarn 1.x defaults to
+# https://registry.yarnpkg.com — a read-only npm mirror — and the auth
+# token above is configured for registry.npmjs.org, so the publish PUT
+# fails with "Not found". Recent runs (v0.1.0-alpha.28, v0.1.0-alpha.29)
+# failed for this reason.
+yarn publish --tag "$TAG" --registry https://registry.npmjs.org


### PR DESCRIPTION
## Context

`yarn publish` in [`bin/publish-npm`](https://github.com/sfcompute/nodes-typescript/blob/main/bin/publish-npm) was hitting `https://registry.yarnpkg.com` — yarn 1.x's default registry, which is a read-only npm mirror — instead of `https://registry.npmjs.org`. The auth token configured on line 5 (`npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"`) only scopes auth for `registry.npmjs.org`, so the publish PUT against yarnpkg.com fell through to an unauthenticated 404:

```
[3/4] Publishing...
error Couldn't publish package: "https://registry.yarnpkg.com/@sfcompute%2fnodes-sdk-alpha: Not found"
```

This silently broke the last two releases — both [`v0.1.0-alpha.28`](https://github.com/sfcompute/nodes-typescript/actions/runs/26016738270) and [`v0.1.0-alpha.29`](https://github.com/sfcompute/nodes-typescript/actions/runs/26017343356) failed identically and never made it to npm. `npm view @sfcompute/nodes-sdk-alpha version` still returns `0.1.0-alpha.27`, and downstream consumers (sfcompute/cli) cannot bump until this is fixed.

The last successful publish was `0.1.0-alpha.27` on 2025-12-06, so something between then and now started pushing yarn toward the default registry — likely a runner image change or a tooling update — but the explicit `--registry` flag makes the publish robust to that drift.

## Description of changes

Adds `--registry https://registry.npmjs.org` to the `yarn publish` invocation in `bin/publish-npm`, with a short comment explaining why it's required.

## Testing

The publish-npm script only runs in CI on a release tag, so I can't dry-run it locally. After this PR lands:

1. Re-run the [Publish NPM workflow](https://github.com/sfcompute/nodes-typescript/actions/workflows/publish-npm.yml) against the `v0.1.0-alpha.29` tag (Actions → Publish NPM → Run workflow, or re-run the failed run for that release).
2. Confirm with `npm view @sfcompute/nodes-sdk-alpha version` once the run succeeds.
3. Repeat for `v0.1.0-alpha.28` if you want both versions on npm.

## Review Callouts

1. **Problem:** Release workflow silently fails on publish because yarn is pointing at the wrong registry; recent releases never reach npm consumers.
2. **API/CLI/Frontend impact:** None at runtime. CI only.
3. **Observability:** None changes.
4. **Unhappy path:** If the npm token is also invalid, the publish will still fail — but now with a clear auth error from npmjs.org instead of a confusing 404 from yarnpkg.com.

[![Open in Indent](https://assets.indent.com/view-in-indent.svg)](https://app.indent.com/chats/1bd30b59-2231-4554-9250-8c363b3e390b) [![Slack Thread](https://assets.indent.com/slack-thread.svg)](https://sfcompute.slack.com/archives/C0AUEJNF9EE/p1778822011363609?thread_ts=1778618809.672159&cid=C0AUEJNF9EE)
Tag `@indent` to continue the conversation here.