### PR TITLE
fix(publish): use `npm publish` so the auth token actually gets used

### DIFF
--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -59,9 +59,11 @@ fi
 
 # Publish with the appropriate tag
 #
-# Explicit --registry is required because yarn 1.x defaults to
-# https://registry.yarnpkg.com — a read-only npm mirror — and the auth
-# token above is configured for registry.npmjs.org, so the publish PUT
-# fails with "Not found". Recent runs (v0.1.0-alpha.28, v0.1.0-alpha.29)
-# failed for this reason.
-yarn publish --tag "$TAG" --registry https://registry.npmjs.org
+# We use `npm publish` rather than `yarn publish` so the script picks up
+# the `_authToken` written via `npm config set` above. yarn 1.x publish
+# silently ignores that auth entry (it issues PUT requests without the
+# bearer token, which npm replies to with 404), so the previous attempts
+# at v0.1.0-alpha.28 and v0.1.0-alpha.29 failed even after pinning the
+# registry. publishConfig.access is set to "public" in package.json, so
+# no --access flag is required.
+npm publish --tag "$TAG"


### PR DESCRIPTION
## Context

Follow-up to [#41](https://github.com/sfcompute/nodes-typescript/pull/41). After pinning yarn's registry to `npmjs.org`, the v0.1.0-alpha.29 publish [still failed](https://github.com/sfcompute/nodes-typescript/actions/runs/26050006283/job/76583998475):

```
+ yarn publish --tag latest --registry https://registry.npmjs.org
info Current version: 0.1.0-alpha.29
[3/4] Publishing...
error Couldn't publish package: "https://registry.npmjs.org/@sfcompute%2fnodes-sdk-alpha: Not found"
```

`yarn publish` is not picking up the `_authToken` entry that `npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"` writes at the top of `bin/publish-npm` — so the PUT goes out unauthenticated and the npm registry replies with 404 (instead of 401). Verified locally that unauthenticated `curl -X PUT https://registry.npmjs.org/@sfcompute%2fnodes-sdk-alpha` returns 404.

## Description of changes

Swap `yarn publish` for `npm publish` in `bin/publish-npm`. `npm publish` reads the same `~/.npmrc` that `npm config set` populated, so the bearer token actually goes out with the request.

`package.json` already has `publishConfig.access = "public"`, so no `--access public` flag is needed.

## Testing

Like #41 — can only be exercised in CI. After this lands:

1. Re-run the [Publish NPM workflow](https://github.com/sfcompute/nodes-typescript/actions/workflows/publish-npm.yml) against `main` (HEAD has the right `version: 0.1.0-alpha.29`).
2. Confirm with `npm view @sfcompute/nodes-sdk-alpha version` — should jump from `0.1.0-alpha.27` to `0.1.0-alpha.29`.

## Review Callouts

1. **Problem:** Release workflow still silently fails after #41 because yarn 1.x publish doesn't respect the npm authToken format the script writes.
2. **API/CLI/Frontend impact:** None at runtime. CI only.
3. **Observability:** None.
4. **Unhappy path:** If the npm token itself is invalid, `npm publish` will fail with a clear `401 Unauthorized` instead of a misleading 404.

[![Open in Indent](https://assets.indent.com/view-in-indent.svg)](https://app.indent.com/chats/1bd30b59-2231-4554-9250-8c363b3e390b) [![Slack Thread](https://assets.indent.com/slack-thread.svg)](https://sfcompute.slack.com/archives/C0AUEJNF9EE/p1778822011363609?thread_ts=1778618809.672159&cid=C0AUEJNF9EE)
Tag `@indent` to continue the conversation here.